### PR TITLE
Accessibility modifiers inside token registry

### DIFF
--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -59,7 +59,7 @@ contract TokenRegistry {
     }
 
     function onTokenMapReqEvent(bytes32[] memory topics, bytes memory data)
-        public
+        internal
     {
         // event TokenMapReq(address indexed tokenReq, uint256 decimals, string name, string symbol);
         address tokenReq = address(uint160(uint256(topics[1])));
@@ -85,7 +85,7 @@ contract TokenRegistry {
         emit TokenMapAck(tokenReq, address(mintAddress));
     }
 
-    function onTokenMapAckEvent(bytes32[] memory topics) public {
+    function onTokenMapAckEvent(bytes32[] memory topics) internal {
         address tokenReq = address(uint160(uint256(topics[1])));
         address tokenAck = address(uint160(uint256(topics[2])));
         require(

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -44,7 +44,9 @@ contract TokenRegistry {
         return (TxTokens.length, RxTokens.length);
     }
 
-    function issueTokenMapReq(ERC20Upgradeable thisSideToken) external returns (address) {
+    function issueTokenMapReq(ERC20Upgradeable thisSideToken)
+        external
+    {
         require(
             TxMapped[address(thisSideToken)] == address(0),
             "token is already mapped"
@@ -85,7 +87,9 @@ contract TokenRegistry {
         emit TokenMapAck(tokenReq, address(mintAddress));
     }
 
-    function onTokenMapAckEvent(bytes32[] memory topics) internal {
+    function onTokenMapAckEvent(bytes32[] memory topics)
+        internal
+    {
         address tokenReq = address(uint160(uint256(topics[1])));
         address tokenAck = address(uint160(uint256(topics[2])));
         require(


### PR DESCRIPTION
Both the functions onTokenMapAckEvent and onTokenMapReqEvent inside tokenRegistry.sol are intended to be executed when the correct event is verified in a block through the execute function of tokenLocker.sol (which inherits tokenRegistry). 

Currently these functions are public, meaning anyone can call them. This means an attacker could add invalid entries to the internal mappings through these functions. From what I can tell the severity of this is limited to causing denial of service to the bridge, due to proper require statements.

Since it seems that these functions are meant to be triggered through execute, parsing an event from another chain, I would recommend these functions be internal. In this case the only public function should be issueTokenMapReq, which starts the req and ack communication between chains. 





Also the issueTokenMapReq function was declared to return an address, but none was actually being returned so I updated its function signature. 







