### PR TITLE
Allow users to pass custom data between chains

### DIFF
--- a/contracts/TokenLocker.sol
+++ b/contracts/TokenLocker.sol
@@ -37,10 +37,9 @@ contract TokenLocker is TokenRegistry {
     );
 
     event HorizonExecute(
-        address reciever,
-        address sendTo,
-        bytes transactionData,
-        uint256 value
+        address indexed reciever,
+        address indexed sendTo,
+        bytes transactionData
     );
 
     bytes32 constant lockEventSig =
@@ -48,7 +47,7 @@ contract TokenLocker is TokenRegistry {
     bytes32 constant burnEventSig =
         keccak256("Burn(address,address,uint256,address)");
     bytes32 constant userEventSig =
-        keccak256("HorizonExecute(address,address,bytes,uint256)");
+        keccak256("HorizonExecute(address,address,bytes)");
 
     address constant ZERO_ADDRESS = 0x0000000000000000000000000000000000000000;
 

--- a/contracts/TokenLocker.sol
+++ b/contracts/TokenLocker.sol
@@ -37,7 +37,6 @@ contract TokenLocker is TokenRegistry {
     );
 
     event HorizonExecute(
-        address indexed reciever,
         address indexed sendTo,
         bytes transactionData
     );
@@ -47,7 +46,7 @@ contract TokenLocker is TokenRegistry {
     bytes32 constant burnEventSig =
         keccak256("Burn(address,address,uint256,address)");
     bytes32 constant userEventSig =
-        keccak256("HorizonExecute(address,address,bytes)");
+        keccak256("HorizonExecute(address,bytes)");
 
     address constant ZERO_ADDRESS = 0x0000000000000000000000000000000000000000;
 

--- a/contracts/TokenLocker.sol
+++ b/contracts/TokenLocker.sol
@@ -116,66 +116,13 @@ contract TokenLocker is TokenRegistry {
                 events++;
                 continue;
             }
-            if (topics[0] == TokenMapAckEventSig) {
+            if (topics[0] == TokenMapAckEventSig) {f
                 onTokenMapAckEvent(topics);
                 events++;
                 continue;
             }
             if (topics[0] == userEventSig) {
                 onUserEvent(topics, Data);
-                events++;
-                continue;
-            }
-        }
-    }
-
-    function _getLogs(bytes memory rlpdata)
-        internal
-        returns (RLPReader.RLPItem[] memory)
-    {
-        RLPReader.RLPItem memory stacks = rlpdata.toRlpItem();
-        RLPReader.RLPItem[] memory receipt = stacks.toList();
-        // TODO: check txs is revert or not
-        uint256 postStateOrStatus = receipt[0].toUint();
-        require(postStateOrStatus == 1, "revert receipt");
-        RLPReader.RLPItem[] memory logs = receipt[3].toList();
-        return logs;
-    }
-
-    function _prepareTopics(RLPReader.RLPItem[] memory rlpLog)
-        internal
-        returns (bytes32[] memory)
-    {
-        RLPReader.RLPItem[] memory Topics = rlpLog[1].toList(); // TODO: if is lock event
-        bytes32[] memory topics = new bytes32[](Topics.length);
-        for (uint256 j = 0; j < Topics.length; j++) {
-            topics[j] = bytes32(Topics[j].toUint());
-        }
-        return topics;
-    }
-
-    //Only execute specified event, because if we execute them all people could
-    //point their call to a contract that reverts to stop any other calls in the block from executing.
-    //This is also why we use a separate function
-    //
-    function executeUserEvent(
-        bytes memory rlpdata,
-        uint256 _eventIndex
-    )
-        internal
-        returns (uint256 events)
-    {
-        _eventIndex = _eventIndex - 1;
-        RLPReader.RLPItem[] memory logs = _getLogs(rlpdata);
-        for (uint256 i = 0; i < logs.length; i++) {
-            RLPReader.RLPItem[] memory rlpLog = logs[i].toList();
-            address Address = rlpLog[0].toAddress();
-            bytes32[] memory topics = _prepareTopics(rlpLog);
-            bytes memory Data = rlpLog[2].toBytes();
-            if (topics[0] == userEventSig) {
-                if(events == _eventIndex){
-                    onUserEvent(topics, Data);
-                }
                 events++;
                 continue;
             }

--- a/contracts/TokenLocker.sol
+++ b/contracts/TokenLocker.sol
@@ -36,10 +36,19 @@ contract TokenLocker is TokenRegistry {
         address recipient
     );
 
+    event HorizonExecute(
+        address reciever,
+        address sendTo,
+        bytes transactionData,
+        uint256 value
+    );
+
     bytes32 constant lockEventSig =
         keccak256("Locked(address,address,uint256,address)");
     bytes32 constant burnEventSig =
         keccak256("Burn(address,address,uint256,address)");
+    bytes32 constant userEventSig =
+        keccak256("HorizonExecute(address,address,bytes,uint256)");
 
     address public otherSideBridge;
 
@@ -112,7 +121,16 @@ contract TokenLocker is TokenRegistry {
                 events++;
                 continue;
             }
+            if (topics[0] == userEventSig) {
+                onUserEvent(topics, Data);
+                events++;
+                continue;
+            }
         }
+    }
+
+    function onUserEvent(bytes32[] memory topics, bytes memory data) private {
+
     }
 
     function onBurnEvent(bytes32[] memory topics, bytes memory data) private {

--- a/contracts/TokenLockerOnEthereum.sol
+++ b/contracts/TokenLockerOnEthereum.sol
@@ -33,6 +33,20 @@ contract TokenLockerOnEthereum is TokenLocker, OwnableUpgradeable {
         MMRVerifier.MMRProof memory mmrProof,
         MPT.MerkleProof memory receiptdata
     ) external {
+        validateAndExecuteProof(
+            header,
+            mmrProof,
+            receiptdata,
+            ZERO_ADDRESS
+        );
+    }
+
+    function validateAndExecuteProof(
+        HarmonyParser.BlockHeader memory header,
+        MMRVerifier.MMRProof memory mmrProof,
+        MPT.MerkleProof memory receiptdata,
+        address userTarget
+    ) public {
         require(lightclient.isValidCheckPoint(header.epoch, mmrProof.root), "checkpoint validation failed");
         bytes32 blockHash = HarmonyParser.getBlockHash(header);
         bytes32 rootHash = header.receiptsRoot;
@@ -48,7 +62,7 @@ contract TokenLockerOnEthereum is TokenLocker, OwnableUpgradeable {
         (status, message) = HarmonyProver.verifyReceipt(header, receiptdata);
         require(status, "receipt data could not be verified");
         spentReceipt[receiptHash] = true;
-        uint256 executedEvents = execute(receiptdata.expectedValue);
+        uint256 executedEvents = execute(receiptdata.expectedValue, userTarget);
         require(executedEvents > 0, "no valid event");
     }
 }

--- a/contracts/TokenLockerOnHarmony.sol
+++ b/contracts/TokenLockerOnHarmony.sol
@@ -38,7 +38,7 @@ contract TokenLockerOnHarmony is TokenLocker, OwnableUpgradeable {
         bytes calldata mptkey,
         bytes calldata proof
     ) external {
-        validateAndExecuteProof(
+        _validateAndExecuteProof(
             blockNo,
             rootHash,
             mptkey,
@@ -47,13 +47,13 @@ contract TokenLockerOnHarmony is TokenLocker, OwnableUpgradeable {
         );
     }
 
-    function validateAndExecuteProof(
+    function _validateAndExecuteProof(
         uint256 blockNo,
         bytes32 rootHash,
         bytes calldata mptkey,
         bytes calldata proof,
         address userTarget
-    ) public {
+    ) internal {
         bytes32 blockHash = bytes32(lightclient.blocksByHeight(blockNo, 0));
         require(
             lightclient.VerifyReceiptsHash(blockHash, rootHash),

--- a/contracts/TokenLockerOnHarmony.sol
+++ b/contracts/TokenLockerOnHarmony.sol
@@ -38,6 +38,22 @@ contract TokenLockerOnHarmony is TokenLocker, OwnableUpgradeable {
         bytes calldata mptkey,
         bytes calldata proof
     ) external {
+        validateAndExecuteProof(
+            blockNo,
+            rootHash,
+            mptkey,
+            proof,
+            ZERO_ADDRESS
+        );
+    }
+
+    function validateAndExecuteProof(
+        uint256 blockNo,
+        bytes32 rootHash,
+        bytes calldata mptkey,
+        bytes calldata proof,
+        address userTarget
+    ) public {
         bytes32 blockHash = bytes32(lightclient.blocksByHeight(blockNo, 0));
         require(
             lightclient.VerifyReceiptsHash(blockHash, rootHash),
@@ -53,7 +69,7 @@ contract TokenLockerOnHarmony is TokenLocker, OwnableUpgradeable {
             proof
         );
         spentReceipt[receiptHash] = true;
-        uint256 executedEvents = execute(rlpdata);
+        uint256 executedEvents = execute(rlpdata, userTarget);
         require(executedEvents > 0, "no valid event");
     }
 }

--- a/contracts/interfaces/IEventExecutor.sol
+++ b/contracts/interfaces/IEventExecutor.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.7.3;
+pragma experimental ABIEncoderV2;
+
+
+
+interface IEventExecutor {
+
+    function executeEvent(
+        bytes calldata _transactionData,
+        address _sendTo,
+        uint256 _value
+    )
+        external
+        returns (bool);
+
+
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -14,7 +14,7 @@ module.exports = {
     networks: {
         localnet: {
             url: `http://localhost:9500`,
-            accounts: [`0x${HARMONY_PRIVATE_KEY}`]
+            accounts: [`0x${HARMONY_PRIVATE_KEY}`],
         },
         testnet: {
             url: `https://api.s0.b.hmny.io`,
@@ -31,7 +31,10 @@ module.exports = {
         ropsten: {
             url: `https://ropsten.infura.io/v3/<project-id>`,
             accounts: [`0x${HARMONY_PRIVATE_KEY}`]
-        }
+        },
+        hardhat: {
+            blockGasLimit: 30000000
+        },
     },
     solidity: {
         version: "0.7.3",
@@ -49,6 +52,9 @@ module.exports = {
         artifacts: "./build"
     },
     mocha: {
-        timeout: 20000
+        timeout: 200000000000
+    },
+    gasReporter: {
+        enabled: true
     }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -7,7 +7,7 @@ require('@openzeppelin/hardhat-upgrades');
  * @type import('hardhat/config').HardhatUserConfig
  */
 
-const HARMONY_PRIVATE_KEY = process.env.PRIVATE_KEY;
+const HARMONY_PRIVATE_KEY = process.env.PRIKEY;
 
 module.exports = {
     defaultNetwork: "hardhat",

--- a/test/testEventRelay.js
+++ b/test/testEventRelay.js
@@ -64,11 +64,22 @@ describe("Token Locker Cross Chain Event Passing", function () {
 
         await LockerOnHarmony.deployed();
 
+        await addBlocksInRange(ELC, rpcUrl, 12274370, 8, './cli/.dag');
+
         const prover = new EProver(rpcUrl);
 
         const proof = await prover.receiptProof(eventTx);
 
-        await addBlocksInRange(ELC, rpcUrl, 12274370, 20, './cli/.dag');
+        await LockerOnHarmony.changeLightClient(ELC.address);
+
+        debug(proof);
+
+        await LockerOnHarmony.validateAndExecuteProof(
+            12274373,
+            proof.root,
+            proof.key,
+            proof.proof
+        );
 
     });
 

--- a/test/testEventRelay.js
+++ b/test/testEventRelay.js
@@ -14,8 +14,18 @@ function hexToBytes(hex) {
 
 const _toHex = e => `0x${e.toString('hex')}`;
 
-async function addBlocksInRange(ELC, rpc){
+async function addBlocksInRange(ELC, rpc, startBlock, numBlocks, dagPath){
+    for (var currentBlock = startBlock; currentBlock < startBlock + numBlocks; currentBlock++){
+        header = await getBlockByNumber(rpc, currentBlock);
 
+        dagProver = new DagProof(dagPath);
+
+        let proofs = dagProver.getProof(header);
+
+        await ELC.addBlockHeader(header.serialize(), proofs.dagData, proofs.proofs, {gasLimit: 3000000 });
+
+        console.log(`added block ${currentBlock} to ELC`);
+    }
 }
 
 function transformNestedByteArray(arr){
@@ -61,19 +71,7 @@ describe("Token Locker Cross Chain Event Passing", function () {
 
         const proof = await prover.receiptProof(eventTx);
 
-        blockNum = await ELC.blockHeightMax();
-
-        header = await getBlockByNumber(rpcUrl, 12274370);
-
-        dagProver = new DagProof('./cli/.dag');
-
-        let proofs = dagProver.getProof(header);
-
-        await ELC.addBlockHeader(header.serialize(), proofs.dagData, proofs.proofs, {gasLimit: 2500000 });
-
-        blockNum = await ELC.blockHeightMax();
-
-        console.log(blockNum);
+        await addBlocksInRange(ELC, rpcUrl, 12274370, 20, './cli/.dag');
 
     });
 

--- a/test/testEventRelay.js
+++ b/test/testEventRelay.js
@@ -1,0 +1,88 @@
+const { expect } = require("chai");
+const { ethers, upgrades } = require("hardhat");
+const block1 = require('./proof1.json');
+const { EProver } = require('../tools/eprover');
+const {getBlockByNumber} = require("../cli/ethashProof/BlockProof");
+const {DagProof} = require('../tools/eth2hmy-relay/lib/DagProof');
+require("hardhat-gas-reporter");
+
+function hexToBytes(hex) {
+    for (var bytes = [], c = 0; c < hex.length; c += 2)
+        bytes.push(parseInt(hex.substr(c, 2), 16));
+    return bytes;
+}
+
+const _toHex = e => `0x${e.toString('hex')}`;
+
+async function addBlocksInRange(ELC, rpc){
+
+}
+
+function transformNestedByteArray(arr){
+    for (var i = 0; i < arr.length; i++){
+        for (var k = 0; k < arr[i].length; k++){
+            arr[i][k] = _toHex(arr[i][k]);
+        }
+    }
+}
+
+const DEBUG = true;
+
+function debug(msg){
+    if(DEBUG) console.log(msg);
+}
+
+const rpcUrl = process.env.RPCURL;
+const eventTx = "0x95f6998ff7c767a0b0d2f2cef4e6975cd5b9d3177dbee35f7b15e54e782ec688";
+
+
+describe("Token Locker Cross Chain Event Passing", function () {
+
+    let ELC, ELCDeployer, LockerOnHarmony, LockerOnHarmonyDeployer, header;
+
+    beforeEach(async function () {
+        const [owner] = await ethers.getSigners();
+
+        ELCDeployer = await ethers.getContractFactory("EthereumLightClient");
+
+        header = await getBlockByNumber(rpcUrl, 12274369);
+
+        ELC = await upgrades.deployProxy(ELCDeployer, [header.serialize()]);
+
+        await ELC.deployed();
+
+        LockerOnHarmonyDeployer = await ethers.getContractFactory("TokenLockerOnHarmony");
+
+        LockerOnHarmony = await upgrades.deployProxy(LockerOnHarmonyDeployer, []);
+
+        await LockerOnHarmony.deployed();
+
+        const prover = new EProver(rpcUrl);
+
+        const proof = await prover.receiptProof(eventTx);
+
+        blockNum = await ELC.blockHeightMax();
+
+        header = await getBlockByNumber(rpcUrl, 12274370);
+
+        dagProver = new DagProof('./cli/.dag');
+
+        let proofs = dagProver.getProof(header);
+
+        await ELC.addBlockHeader(header.serialize(), proofs.dagData, proofs.proofs, {gasLimit: 2500000 });
+
+        blockNum = await ELC.blockHeightMax();
+
+        console.log(blockNum);
+
+    });
+
+    it("Add surrounding blocks to ELC", async function () {
+
+    });
+
+    describe("Test Event Relaying/Proving", function() {
+        it("Execute add token event from stored transaction", async function () {
+        })
+    })
+});

--- a/test/testEventRelay.js
+++ b/test/testEventRelay.js
@@ -6,13 +6,20 @@ const {getBlockByNumber} = require("../cli/ethashProof/BlockProof");
 const {DagProof} = require('../tools/eth2hmy-relay/lib/DagProof');
 require("hardhat-gas-reporter");
 
+const rpcUrl = process.env.RPCURL;
+const eventTx = "0x95f6998ff7c767a0b0d2f2cef4e6975cd5b9d3177dbee35f7b15e54e782ec688";
+const DEBUG = true;
+const _toHex = e => `0x${e.toString('hex')}`;
+
+function debug(msg){
+    if(DEBUG) console.log(msg);
+}
+
 function hexToBytes(hex) {
     for (var bytes = [], c = 0; c < hex.length; c += 2)
         bytes.push(parseInt(hex.substr(c, 2), 16));
     return bytes;
 }
-
-const _toHex = e => `0x${e.toString('hex')}`;
 
 async function addBlocksInRange(ELC, rpc, startBlock, numBlocks, dagPath){
     for (var currentBlock = startBlock; currentBlock < startBlock + numBlocks; currentBlock++){
@@ -35,16 +42,6 @@ function transformNestedByteArray(arr){
         }
     }
 }
-
-const DEBUG = true;
-
-function debug(msg){
-    if(DEBUG) console.log(msg);
-}
-
-const rpcUrl = process.env.RPCURL;
-const eventTx = "0x95f6998ff7c767a0b0d2f2cef4e6975cd5b9d3177dbee35f7b15e54e782ec688";
-
 
 describe("Token Locker Cross Chain Event Passing", function () {
 


### PR DESCRIPTION
Uses the event structure for mint/burn ect events to add an event where any user can emit an event that will allow code to be executed on the other chain.

User must call the validateAndExecuteProof function separately providing the contract address to listen for events from. The event passes the address to call and a bytes array of arbitrary data. The bridge contract then calls the specified address with the function signature HorizonExecute(address,bytes). The address passed is the address of the contract on the other side of the bridge that emitted the event. This allows permissioning of the other side contract specifcally, so that not any contract can emit the event and trigger behavior of contracts on the other chain.

Leaving this PR in draft for now because I am having problems getting the proof generated from the DagProof CLI file to be verified by the validateMPTProof of EthereumProver.sol, therefore preventing me from accessing and testing any of the new code for this feature at the mement.
